### PR TITLE
fix invalid variable name for login to heroku on master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,11 +85,10 @@ jobs:
           name: Deploy if tests pass and branch is Master
           shell: /bin/bash
           command: |
-            export HEROKU_API_KEY=${!HEROKU_API_KEY_MASTER}
+            export HEROKU_API_KEY=${HEROKU_API_KEY_MASTER}
             heroku container:login
             heroku container:push web -a zeton1
             heroku container:release web -a zeton1
-
 
 workflows:
   version: 2
@@ -112,6 +111,3 @@ workflows:
           filters:
             branches:
               only: master
-
-
-


### PR DESCRIPTION
fix config.yml 
For branch `master` was an error with login to Heroku for deploy-prod step. The error related to incorrect variable name during a login attempt. The reason was a redundant `!` in a bash script. 